### PR TITLE
chore: add installation via npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ npm install @ryangjchandler/alpine-clipboard
 
 > Also available via yarn add @ryangjchandler/alpine-clipboard
 
-Add `$clipboard` to your project by imported before Alpine.js.
+Add the `$clipboard` magic property to your project by importing the package **before** Alpine.js.
 
 ```js
 import "@ryangjchandler/alpine-clipboard"

--- a/README.md
+++ b/README.md
@@ -14,11 +14,26 @@ This plugin adds a new `$clipboard` magic property to all of your Alpine compone
 
 ## Installation
 
+### NPM
+
+```bash
+npm install @ryangjchandler/alpine-clipboard
+```
+
+> Also available via yarn add @ryangjchandler/alpine-clipboard
+
+Add `$clipboard` to your project by imported before Alpine.js.
+
+```js
+import "@ryangjchandler/alpine-clipboard"
+// import "alpinejs"
+```
+
 ### CDN
 
 Include the following `<script>` tag in the `<head>` of your document:
 
-``` html
+```html
 <script src="https://cdn.jsdelivr.net/npm/@ryangjchandler/alpine-clipboard@0.1.x/dist/alpine-clipboard.umd.js"></script>
 ```
 

--- a/README.md
+++ b/README.md
@@ -14,21 +14,6 @@ This plugin adds a new `$clipboard` magic property to all of your Alpine compone
 
 ## Installation
 
-### NPM
-
-```bash
-npm install @ryangjchandler/alpine-clipboard
-```
-
-> Also available via yarn add @ryangjchandler/alpine-clipboard
-
-Add the `$clipboard` magic property to your project by importing the package **before** Alpine.js.
-
-```js
-import "@ryangjchandler/alpine-clipboard"
-// import "alpinejs"
-```
-
 ### CDN
 
 Include the following `<script>` tag in the `<head>` of your document:
@@ -38,6 +23,19 @@ Include the following `<script>` tag in the `<head>` of your document:
 ```
 
 > **Important**: This must be added **before** loading Alpine.js when using CDN links.
+
+### NPM
+
+```bash
+npm install @ryangjchandler/alpine-clipboard
+```
+
+Add the `$clipboard` magic property to your project by importing the package **before** Alpine.js.
+
+```js
+import "@ryangjchandler/alpine-clipboard"
+// import "alpinejs"
+```
 
 ## Usage
 


### PR DESCRIPTION
This PR adds steps for installing `$clipboard` via NPM, couldn't personally get it to work with node's `require` so went with `import` instead.

Closes #3 