### PR TITLE
Add note about needed secure context for this to work

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ window.Alpine.start()
 
 ## Usage
 
+> **Note**
+> The Clipboard Web-API requires a secure context (i.e. https) to function in most browsers ([more info](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard)).
+
 To copy some data to the clipboard, invoke `$clipboard` from an event handler in your component.
 
 ```html

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ window.Alpine.start()
 ## Usage
 
 > **Note**
-> The Clipboard Web-API requires a secure context (i.e. https) to function in most browsers ([more info](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard)).
+> The Clipboard API that this package uses only works in a secure context (`https`) and `localhost`. 
 
 To copy some data to the clipboard, invoke `$clipboard` from an event handler in your component.
 


### PR DESCRIPTION
At least in Chrome this doesn't work when not using https. So to avoid confusion for others I propose adding this note. :-)